### PR TITLE
Add http PDF fetcher

### DIFF
--- a/chathelper/cache.py
+++ b/chathelper/cache.py
@@ -66,6 +66,13 @@ def find_paper(paper: ChatDocument, cache_dir: Path) -> Optional[Path]:
     return p if p.exists() else None
 
 
+def update_metadata(doc: Document, paper: ChatDocument):
+    """Update the metadata of a document"""
+    doc.metadata["chatter_tags"] = paper.tags
+    if paper.title is not None:
+        doc.metadata["Title"] = paper.title
+
+
 @throttle(10)
 def do_download(paper: ChatDocument, cache_dir: Path, paper_path: Path):
     # Now parse and figure out how to get the thing
@@ -101,7 +108,7 @@ def do_download(paper: ChatDocument, cache_dir: Path, paper_path: Path):
         cache_dir.mkdir(parents=True)
 
     # Add the metadata tags
-    data[0].metadata["chatter_tags"] = paper.tags
+    update_metadata(data[0], paper)
 
     # Finally, save it!
     with open(paper_path, "wb") as f:
@@ -150,7 +157,7 @@ def load_paper(paper: ChatDocument, cache_dir: Path) -> Optional[Document]:
 
     with open(paper_path, "rb") as f:
         r = pickle.load(f)
-        r.metadata["chatter_tags"] = paper.tags
+        update_metadata(r, paper)
         return r
 
 

--- a/chathelper/cache.py
+++ b/chathelper/cache.py
@@ -69,6 +69,7 @@ def find_paper(paper: ChatDocument, cache_dir: Path) -> Optional[Path]:
 def update_metadata(doc: Document, paper: ChatDocument):
     """Update the metadata of a document"""
     doc.metadata["chatter_tags"] = paper.tags
+    doc.metadata["chatter_ref"] = paper.ref
     if paper.title is not None:
         doc.metadata["Title"] = paper.title
 

--- a/chathelper/cache.py
+++ b/chathelper/cache.py
@@ -2,8 +2,11 @@ import pickle
 from pathlib import Path
 from typing import Callable, Iterable, Optional
 from urllib.parse import urlparse
+import requests
+
 
 from langchain.schema.document import Document
+from langchain.document_loaders import UnstructuredPDFLoader
 
 from chathelper.utils import throttle
 
@@ -38,9 +41,12 @@ def _paper_path(paper: ChatDocument, cache_dir: Path) -> Path:
     # names get calculated - might want something that uses
     # all elements of a url (thinking about you, indico!).
     if r.scheme == "https" or r.scheme == "http":
-        raise NotImplementedError(
-            f"Arbitrary URL is not implemented as paper source {paper.ref}"
-        )
+        filename = r.path.split("/")[-1]
+        if not filename.endswith(".pdf"):
+            raise NotImplementedError(
+                f"Invalid URL {paper.ref} (must end with '.pdf'?)"
+            )
+        return cache_dir / f"{Path(filename).stem}.pickle"
 
     return cache_dir / f"{r.netloc}.pickle"
 
@@ -61,7 +67,7 @@ def find_paper(paper: ChatDocument, cache_dir: Path) -> Optional[Path]:
 
 
 @throttle(10)
-def do_download(paper, cache_dir, paper_path):
+def do_download(paper: ChatDocument, cache_dir: Path, paper_path: Path):
     # Now parse and figure out how to get the thing
     uri = urlparse(paper.ref)
     if uri.scheme == "arxiv":
@@ -72,6 +78,16 @@ def do_download(paper, cache_dir, paper_path):
             doc_content_chars_max=None,
             keep_pdf=True,
         )
+        data = loader.load()
+    elif uri.scheme == "http" or uri.scheme == "https":
+        # Download the PDF locally from the uri using the `requests` library.
+        # This is a bit of a hack, but it works.
+        r = requests.get(paper.ref)
+        pdf_path = (Path(".") / f"{paper_path.stem}.pdf").absolute()
+        if not pdf_path.exists():
+            with pdf_path.open("wb") as f:
+                f.write(r.content)
+        loader = UnstructuredPDFLoader(str(pdf_path))
         data = loader.load()
     else:
         raise NotImplementedError(f"Unknown scheme {uri.scheme} for {paper.ref}")

--- a/chathelper/config.py
+++ b/chathelper/config.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 from pydantic import BaseModel
 import yaml
 
@@ -9,6 +9,8 @@ class ChatDocument(BaseModel):
 
     # Tags is a list of tags (like the frontier, etc.) attached to the thing
     tags: list[str]
+
+    title: Optional[str] = None
 
     class Config:
         _env_file = "bogus.yaml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "chromadb",
     "tiktoken",
     "rich",
+    "unstructured[local-inference]",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,7 +1,9 @@
+from pathlib import Path
 import pickle
 from unittest.mock import patch
 
 import pytest
+from langchain.document_loaders import UnstructuredPDFLoader
 
 from chathelper.cache import (
     _paper_path,
@@ -43,6 +45,19 @@ def test_paper_path(tmp_path):
         == tmp_path / "2203.01009.pickle"
     )
 
+    # URL https://www.slac.stanford.edu/econf/C210711/reports/ExecutiveSummary.pdf
+    assert (
+        _paper_path(
+            ChatDocument(
+                ref="https://www.slac.stanford.edu/econf/C210711/reports/"
+                "ExecutiveSummary.pdf",
+                tags=[],
+            ),
+            tmp_path,
+        )
+        == tmp_path / "ExecutiveSummary.pickle"
+    )
+
     # Local path
     assert (
         _paper_path(ChatDocument(ref="file:///tmp/2203.01009.pdf", tags=[]), tmp_path)
@@ -58,7 +73,7 @@ def test_paper_path_bad(tmp_path):
             ChatDocument(
                 ref="https://indico.cern.ch/event/1242538/contributions/"
                 "5432836/attachments/2689673/4669514/"
-                "2023%20-%20MODE%20-%20NN%20and%20Cuts.pdf",
+                "2023%20-%20MODE%20-%20NN%20and%20Cuts",
                 tags=[],
             ),
             tmp_path,
@@ -102,7 +117,7 @@ def test_download_archive_loaded(mock_load, tmp_path):
 @patch.object(ArxivLoader, "__init__", return_value=None)
 @patch.object(ArxivLoader, "load", return_value=[_dummy_document()])
 def test_download_arxiv(mock_load, mock_init, tmp_path):
-    "Download a paper to the cache"
+    "Make sure the Archive loader is called correctly"
     paper_name = "2109.10905"
 
     cache_dir = tmp_path / "cache"
@@ -116,6 +131,29 @@ def test_download_arxiv(mock_load, mock_init, tmp_path):
         load_all_available_meta=True,
         doc_content_chars_max=None,
     )
+
+
+@patch.object(UnstructuredPDFLoader, "__init__", return_value=None)
+@patch.object(UnstructuredPDFLoader, "load", return_value=[_dummy_document()])
+def test_download_pdf_From_url(mock_load, mock_init, tmp_path):
+    "Download a pdf from a url"
+    paper_name = (
+        "https://www.slac.stanford.edu/econf/C210711/reports/ExecutiveSummary.pdf"
+    )
+
+    cache_dir = tmp_path
+
+    paper = ChatDocument(ref=f"{paper_name}", tags=[])
+    download_paper(paper, cache_dir)
+
+    downloaded = find_paper(paper, cache_dir)
+    assert downloaded is not None
+    assert downloaded.exists()
+
+    mock_load.assert_called_once()
+
+    arg = mock_init.call_args[0][0]
+    assert Path(arg).name == "ExecutiveSummary.pdf"
 
 
 @patch.object(ArxivLoader, "load", side_effect=ValueError("should not be called"))

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -188,7 +188,7 @@ def test_load_cached(tmp_path):
 
 def test_load_cached_new_metadata(tmp_path):
     cache_dir = tmp_path / "cache"
-    paper = ChatDocument(ref="arxiv://2109.10905", tags=["WF"])
+    paper = ChatDocument(ref="arxiv://2109.10905", tags=["WF"], title="fork")
 
     expected_paper_path = _paper_path(paper, cache_dir)
     expected_paper_path.parent.mkdir(exist_ok=True, parents=True)
@@ -198,6 +198,7 @@ def test_load_cached_new_metadata(tmp_path):
     p = load_paper(paper, cache_dir)
     assert p is not None
     assert p.metadata["chatter_tags"] == ["WF"]
+    assert p.metadata["Title"] == "fork"
 
 
 def test_download_all(tmp_path):


### PR DESCRIPTION
* Allow `http` and `https` urls
   * But URL must end in `.pdf` for now.
* Download locally so a copy of the pdf file is availible
* Use the `unstructured` library to parse the pdf, which might be what we want everything to do eventually.
* add a `title` entry for snowmass papers, useful to proivde a title which the PDF stuff can't really do currently.

Fixes #10