### PR TITLE
Add keyword extraction functionality

### DIFF
--- a/experimental/README.md
+++ b/experimental/README.md
@@ -5,3 +5,4 @@ Some experimental efforts - short code snippets that try things out - and probab
 Make sure to look at requirements.txt to see what else needs to be loaded
 
 * `lc_archive_loader.py` Testing out the archive loader, getting as far as splitting, making sure we can write out/pickle files.
+* `lc_keywords.py` Grab the keywords for a particular PDF file using `rake-nltk`. Experimental.

--- a/experimental/lc_keywords.py
+++ b/experimental/lc_keywords.py
@@ -1,0 +1,69 @@
+import argparse
+from rake_nltk import Rake
+from rich.table import Table
+from rich.console import Console
+
+from chathelper.lc_experimental.archive_loader import ArxivLoader
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Extract keywords from a PDF file.")
+    parser.add_argument(
+        "pdf_path",
+        type=str,
+        help="Archive search string",
+        default="id:2109.10905",
+        nargs="?",
+    )
+    args = parser.parse_args()
+
+    # Use the 'pdf_path' argument in your code
+    pdf_path = args.pdf_path
+    print(pdf_path)
+
+    # Extract the complete text from the PDF file.
+    loader = ArxivLoader(
+        pdf_path,
+        load_all_available_meta=True,
+        doc_content_chars_max=None,
+        keep_pdf=True,
+    )
+    data = loader.load()
+
+    print(len(data))
+    assert len(data) == 1
+
+    good_doc = data[0]
+    # print(good_doc.page_content)
+
+    # Use rake to get the list of keywords.
+
+    # Uses stop-words for english from NLTK, and all punctuation characters by
+    # default
+    r = Rake(max_length=3)
+
+    # Extraction given the text.
+    r.extract_keywords_from_text(good_doc.page_content)
+
+    # To get keyword phrases ranked highest to lowest with scores.
+    results = r.get_ranked_phrases_with_scores()
+
+    # Create a rich table with the header and the two columns
+    table = Table(title="Keyword Rankings")
+    table.add_column("Index", justify="right", style="green")
+    table.add_column("Rank Score", justify="right", style="cyan")
+    table.add_column("Keyword", style="magenta")
+
+    seen = set()
+    for index, (score, keyword) in enumerate(results):
+        if keyword not in seen and len(seen) < 500:
+            table.add_row(str(index), str(score), keyword)
+            seen.add(keyword)
+
+    # Print the table
+    console = Console()
+    console.print(table)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.10"
 
 dependencies = [
     "PyYAML",
-    "pydantic",
+    "pydantic~=1.8",
     "fsspec[http]",
     "requests",
     "openai",
@@ -22,6 +22,10 @@ dependencies = [
     "tiktoken",
     "rich",
     "unstructured[local-inference]",
+    "rake-nltk",
+    "langchain",
+    "arxiv",
+    "pymupdf",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
This pull request adds a new feature to the system that allows for keyword extraction from PDF files. The `lc_keywords.py` file has been added, which uses the `rake-nltk` library to extract keywords from a given PDF file. The extracted keywords are then displayed in a ranked table using the `rich` library. This feature can be useful for analyzing and categorizing PDF documents based on their content.

Fixes #22