### PR TITLE
Recovering

### DIFF
--- a/chathelper/cache.py
+++ b/chathelper/cache.py
@@ -85,6 +85,7 @@ def do_download(paper: ChatDocument, cache_dir: Path, paper_path: Path):
             load_all_available_meta=True,
             doc_content_chars_max=None,
             keep_pdf=True,
+            cache_dir=cache_dir,
         )
         data = loader.load()
     elif uri.scheme == "http" or uri.scheme == "https":

--- a/chathelper/cache.py
+++ b/chathelper/cache.py
@@ -6,7 +6,7 @@ import requests
 
 
 from langchain.schema.document import Document
-from langchain.document_loaders import UnstructuredPDFLoader
+from langchain_community.document_loaders import UnstructuredPDFLoader
 
 from chathelper.utils import throttle
 

--- a/chathelper/lc_experimental/archive_loader.py
+++ b/chathelper/lc_experimental/archive_loader.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
+from pathlib import Path
 
 from .arxiv import ArxivAPIWrapper
 
@@ -20,6 +21,7 @@ class ArxivLoader(BaseLoader):
         load_all_available_meta: Optional[bool] = False,
         doc_content_chars_max: Optional[int] = 40000,
         keep_pdf: bool = False,
+        cache_dir: Optional[Path] = None,
     ):
         self.query = query
         """The query to be passed to the arxiv.org API."""
@@ -31,6 +33,8 @@ class ArxivLoader(BaseLoader):
         """The maximum number of characters to load from the document content."""
         self.keep_pdf = keep_pdf
         """Whether to keep the PDF file on disk where it is downloaded."""
+        self.cache_dir = cache_dir if cache_dir is not None else Path(".")
+        """The directory where the PDF files are stored when downloaded."""
 
     def load(self) -> List[Document]:
         arxiv_client = ArxivAPIWrapper(
@@ -38,6 +42,7 @@ class ArxivLoader(BaseLoader):
             load_all_available_meta=self.load_all_available_meta,
             doc_content_chars_max=self.doc_content_chars_max,
             keep_pdf=self.keep_pdf,
+            cache_dir=self.cache_dir,
         )  # type: ignore
         docs = arxiv_client.load(self.query)
         return docs

--- a/chathelper/lc_experimental/arxiv.py
+++ b/chathelper/lc_experimental/arxiv.py
@@ -1,6 +1,8 @@
 """Util that calls Arxiv."""
+
 import logging
 import os
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, root_validator
@@ -57,6 +59,7 @@ class ArxivAPIWrapper(BaseModel):
     load_all_available_meta: bool = False
     doc_content_chars_max: Optional[int] = 4000
     keep_pdf: bool = False
+    cache_dir: Path = Path(".")
 
     @root_validator()
     def validate_environment(cls, values: Dict) -> Dict:
@@ -141,7 +144,7 @@ class ArxivAPIWrapper(BaseModel):
         docs: List[Document] = []
         for result in results:
             try:
-                doc_file_name: str = result.download_pdf()
+                doc_file_name: str = result.download_pdf(dirpath=self.cache_dir)
                 with fitz.open(doc_file_name) as doc_file:  # type: ignore
                     text: str = "".join(page.get_text() for page in doc_file)
             except FileNotFoundError as f_ex:

--- a/chathelper/model.py
+++ b/chathelper/model.py
@@ -3,10 +3,10 @@ from pathlib import Path
 from typing import Callable, Iterable, List, Optional
 
 from langchain.chains import RetrievalQA
-from langchain.chat_models import ChatOpenAI
-from langchain.embeddings import OpenAIEmbeddings
+from langchain_community.chat_models import ChatOpenAI
+from langchain_community.embeddings import OpenAIEmbeddings
 from langchain.text_splitter import RecursiveCharacterTextSplitter
-from langchain.vectorstores import Chroma
+from langchain_community.vectorstores import Chroma
 from pydantic import BaseModel
 
 from chathelper.cache import load_paper

--- a/experimental/lc_arxiv_loader.py
+++ b/experimental/lc_arxiv_loader.py
@@ -54,7 +54,7 @@ all_splits = text_splitter.split_documents([good_doc_prime])
 print(len(all_splits))
 
 # Now, put it in the vector store
-from langchain.embeddings import OpenAIEmbeddings
+from langchain_community.embeddings import OpenAIEmbeddings
 from langchain.vectorstores import Chroma
 
 # Need api key for this next bit - to access the embeddings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "rich",
     "unstructured[local-inference]",
     "langchain",
+    "langchain-community",
     "arxiv",
     "pymupdf",
     "spacy",

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -3,7 +3,7 @@ import pickle
 from unittest.mock import patch
 
 import pytest
-from langchain.document_loaders import UnstructuredPDFLoader
+from langchain_community.document_loaders import UnstructuredPDFLoader
 
 from chathelper.cache import (
     _paper_path,


### PR DESCRIPTION
We've not used this in a while. Getting it running on a new machine:

* Updates because `langchain` has moved on
* Added the ability to download the PDF's into the cache directory rather than polute your current directory.
