### PR TITLE
Enable other chat models

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Getting from a list of documents to a working chat-bot follows the below steps:
 1. Make your query
     * Use `chatter -c snowmass/snowmass.yaml query ask "What does the MATHUSLA experiment do?`
     * Change `ask` to `find` to see what chunks of text are used by the LLM to answer your question.
+    * Use the new gpt 4.5 turbo from the command line: `chatter -c snowmass/snowmass.yaml query ask -q "gpt-4-turbo-preview" "What does the MATHUSLA experiment do?"`, or set it as the default:
 1. Generate answers file for comparison
     * Generate a `yaml` file contains the answers to a list of questions
         * `chatter -c snowmass/snowmass.yaml questions --questions_file snowmass/snowmass-questions.yaml ask "Default config, but updated code" snowmass/snowmass-v1.0-update.yaml`

--- a/chathelper/cli.py
+++ b/chathelper/cli.py
@@ -523,6 +523,19 @@ def questions_ask(args):
         yaml.dump(qanda.dict(), f)
 
 
+def default_list(args):
+    """List the defaults"""
+    print(f"Query Model: {config_cache().query_model}")
+
+
+def default_set(args):
+    """Set a default"""
+    if args.key == "query_model":
+        config_cache().query_model = args.value
+    else:
+        raise ValueError(f"Unknown default key {args.key}")
+
+
 def execute_command_line():
     """Parse command line arguments using the `argparse` module as a series of
     sub-commands.
@@ -758,6 +771,27 @@ def execute_command_line():
         help="Print the table in markdown format",
     )
     questions_compare_parser.set_defaults(func=questions_compare)
+
+    # The default sub command works with defaults for processing, like the
+    # default OpenAI LLM model. It has sub-commands like list (which lists all of the
+    # defaults), and set (which sets a default).
+    defaults_parser = subparsers.add_parser("defaults", help="Working with defaults")
+    defaults_parser.set_defaults(func=lambda _: defaults_parser.print_help())
+    defaults_subparsers = defaults_parser.add_subparsers(help="Possible Commands")
+
+    # list the defaults
+    defaults_list_parser = defaults_subparsers.add_parser(
+        "list", help="List the defaults"
+    )
+    defaults_list_parser.set_defaults(func=default_list)
+
+    # The set command will set a default
+    defaults_set_parser = defaults_subparsers.add_parser("set", help="Set a default")
+    defaults_set_parser.add_argument(
+        "key", help="The key to set", type=str, choices=["query_model"]
+    )
+    defaults_set_parser.add_argument("value", help="The value to set the key to")
+    defaults_set_parser.set_defaults(func=default_set)
 
     # Parse the arguments
     args = parser.parse_args(namespace=None)

--- a/chathelper/cli.py
+++ b/chathelper/cli.py
@@ -501,7 +501,10 @@ def questions_ask(args):
         )
 
     # Build the description
-    description = f"{args.description} (-n {args.n})"
+    description = (
+        f"{args.description} (-n {args.n}, "
+        f"{args.query_model or config_cache().query_model})"
+    )
 
     questions = load_questions(args.questions_file)
 

--- a/chathelper/cli.py
+++ b/chathelper/cli.py
@@ -81,6 +81,14 @@ class config_cache:
         keys[key] = value
         self._update({"keys": keys})
 
+    @property
+    def query_model(self) -> str:
+        return self._load().get("query_model", "gpt-3.5-turbo")
+
+    @query_model.setter
+    def query_model(self, value: str) -> None:
+        self._update({"query_model": value})
+
 
 def load_config(args) -> ChatConfig:
     """Load the config file from the command line arguments
@@ -398,7 +406,13 @@ def ask_from_args(args, query: str) -> Dict[str, Any]:
     if openai_key is None:
         raise ValueError("No OpenAI API key set, use chatter set key openai <key>")
 
-    return query_llm(vector_dir, openai_key, query, int(args.n or 4))
+    return query_llm(
+        vector_dir,
+        openai_key,
+        query,
+        args.query_model or config_cache().query_model,
+        int(args.n or 4),
+    )
 
 
 def query_ask(args):
@@ -639,6 +653,13 @@ def execute_command_line():
     # The ask command queries the LLM for the answer to a question.
     def ask_args(parser):
         parser.add_argument("-n", help="The number of results to return", default=4)
+        parser.add_argument(
+            "--query_model",
+            "-q",
+            help="Use a different query model (default is whatever is set in the config)",
+            type=str,
+            default=None,
+        )
 
     query_ask_parser = query_subparsers.add_parser("ask", help="Ask the LLM a question")
     query_ask_parser.add_argument("query", help="The question to ask")

--- a/chathelper/model.py
+++ b/chathelper/model.py
@@ -178,11 +178,12 @@ def query_llm(
     vector_store_path: Path,
     api_key: SecretStr,
     query: str,
+    query_model: str,
     n_chunks: int = 4,
 ):
     # Vector store db and embedding function
     vector_store = load_vector_store_database(vector_store_path, api_key)
-    llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0, api_key=api_key)
+    llm = ChatOpenAI(model=query_model, temperature=0, api_key=api_key)
     ret = vector_store.as_retriever()
     ret.search_kwargs = {"k": n_chunks}
     qa_chain = RetrievalQA.from_chain_type(llm, retriever=ret)

--- a/snowmass/snowmass-v1.0-gtp4-turbo.yaml
+++ b/snowmass/snowmass-v1.0-gtp4-turbo.yaml
@@ -1,0 +1,270 @@
+description: Using GPT-4-turbo (-n 4, gpt-4-turbo-preview)
+questions:
+- answer: The FASER experiment is designed to probe long-lived dark sectors within
+    an Effective Field Theory (EFT) framework. It focuses on investigating fermion
+    portal four-fermion interactions of the vector and axial-vector forms. FASER2,
+    an upgrade of the FASER experiment, incorporates a magnetized spectrometer and
+    tracking detector to search for decays of new long-lived particles predicted by
+    models of new physics. This upgrade aims to significantly increase the sensitivity
+    to light and weakly-interacting states, including long-lived particles, new force
+    carriers, axion-like particles, light neutralinos, and dark sector particles,
+    enhancing the experiment's ability to detect phenomena with a relatively small
+    cross section.
+  question: What does the FASER experiment do?
+- answer: The MATHUSLA experiment (MAssive Timing Hodoscope for Ultra-Stable neutraL
+    pArticles) is designed to detect long-lived particles that might be produced at
+    the Large Hadron Collider (LHC). These particles, if they exist, could be candidates
+    for dark matter or could provide insights into other new physics beyond the Standard
+    Model of particle physics. The experiment aims to complement other LHC experiments
+    by searching for particles that escape detection by traditional methods, due to
+    their long lifetimes and the fact that they decay far from the collision point.
+    MATHUSLA would be able to detect these decays through a large surface detector
+    placed at a significant distance from the LHC beamline, allowing it to observe
+    particles that travel a considerable distance before decaying. This approach opens
+    up the possibility of exploring new physics scenarios and could help address some
+    of the outstanding questions in particle physics, such as the nature of dark matter.
+  question: What does the MATHUSLA experiment do?
+- answer: 'The ATLAS experiment is one of the major experiments at the CERN Large
+    Hadron Collider (LHC). It is designed to explore a wide range of physics questions,
+    aiming to improve our understanding of the fundamental particles and forces that
+    shape our universe. The ATLAS detector is a multi-purpose particle physics apparatus
+    that captures and measures particles produced by proton-proton collisions within
+    the LHC. Some of its primary goals include:
+
+
+    1. **Search for the Higgs boson**: ATLAS played a crucial role in the discovery
+    of the Higgs boson in 2012, a particle that is associated with the mechanism that
+    gives mass to elementary particles.
+
+
+    2. **Investigate the properties of the Higgs boson**: Following its discovery,
+    ATLAS continues to study the Higgs boson''s properties in detail, such as its
+    interactions with other particles and its role in the universe.
+
+
+    3. **Search for signs of new physics**: This includes looking for evidence of
+    supersymmetry (SUSY), extra dimensions, and other phenomena that go beyond the
+    Standard Model of particle physics.
+
+
+    4. **Study the fundamental forces**: ATLAS examines the interactions between particles
+    to understand better the forces that govern them, including the strong and weak
+    nuclear forces and electroweak symmetry breaking.
+
+
+    5. **Understand the behavior of the early universe**: By recreating conditions
+    similar to those just after the Big Bang, ATLAS can provide insights into the
+    early universe''s state and the formation of its fundamental structures.
+
+
+    The ATLAS experiment is a collaborative effort involving thousands of scientists
+    from around the world, utilizing one of the most complex and sophisticated scientific
+    instruments ever built to push the boundaries of human knowledge about the universe.'
+  question: What does the ATLAS experiment do?
+- answer: The CMS (Compact Muon Solenoid) Experiment is a large-scale physics project
+    located at the Large Hadron Collider (LHC) at CERN (European Organization for
+    Nuclear Research). It is one of the major experiments at the LHC, designed to
+    investigate a wide range of physics phenomena, including the search for the Higgs
+    boson, which was successfully discovered in 2012 in collaboration with another
+    LHC experiment, ATLAS. The CMS Experiment aims to explore the fundamental structure
+    of the universe by studying the properties of particles that are produced when
+    protons collide at very high energies within the LHC. It examines the results
+    of these collisions for evidence of new particles and to test theories of particle
+    physics, including the Standard Model and beyond. The CMS detector is a general-purpose
+    detector, equipped to measure the energy and momentum of photons, electrons, muons,
+    and other particles with high precision, enabling a broad physics program that
+    covers topics such as the Higgs boson, dark matter, extra dimensions, and the
+    properties of the quark-gluon plasma.
+  question: What does the CMS experiment do?
+- answer: 'The LHCb experiment is a single-arm forward spectrometer located at the
+    Large Hadron Collider (LHC). It is specifically designed to study the properties
+    of particles that contain bottom (b) and charm (c) quarks. Unlike lepton colliders,
+    hadron colliders like the LHC generate a vast number of elementary particles with
+    each collision, including bb pairs with a significant cross-section. Despite its
+    smaller luminosity and detector coverage compared to other experiments at the
+    LHC, LHCb''s unique design allows it to effectively cover particles produced at
+    small angles to the beam. This capability makes it competitive with general-purpose
+    detectors for certain types of new particle searches, especially for Higgs decays
+    into long-lived particles.
+
+
+    LHCb, along with experiments like Belle II, focuses on the decays of bottom and
+    charm quarks, as well as tau leptons. The experiment operates in a high-rate,
+    broad-spectrum production environment of proton-proton collisions, which complements
+    the clean, controlled environment of electron-positron collisions studied in experiments
+    like Belle II. This setup enables LHCb to probe Standard Model predictions for
+    quark behavior and lepton physics with unprecedented precision. It also allows
+    for the exploration of new physics paradigms, including leptoquark searches and
+    the study of electroweak parameters, heavy Majorana neutrinos, and lepton flavor-violating
+    decays.
+
+
+    A notable innovation in the LHCb upgrade is the implementation of a software trigger
+    that processes data in real-time, as opposed to relying on a simple first-level
+    filtering scheme based on hardware thresholds. This advanced triggering strategy
+    enhances the experiment''s ability to adjust its data collection parameters dynamically,
+    significantly improving its efficiency and effectiveness in capturing relevant
+    data for its research objectives.'
+  question: What does the LHCb experiment do?
+- answer: "The CODEX-b experiment is designed to study long-lived particles (LLPs)\
+    \ by exploiting the production cross section and luminosity delivered by the Large\
+    \ Hadron Collider (LHC) over the next two decades. It aims to fill a unique role\
+    \ in the experimental landscape by being relatively compact, affordable, and capable\
+    \ of being implemented using proven technology. The core advantages of CODEX-b\
+    \ include:\n\n1. Competitive sensitivity to a wide range of Beyond the Standard\
+    \ Model (BSM) LLP scenarios, either exceeding or complementing the sensitivity\
+    \ of existing or proposed detectors.\n2. A zero background environment, which\
+    \ enhances its ability to detect LLP events without interference from other signals.\n\
+    3. An accessible experimental location with many of the necessary services already\
+    \ in place, making it easier and more cost-effective to implement.\n4. The ability\
+    \ to tag events of interest within the existing LHCb data stream, which allows\
+    \ for a more efficient identification and analysis of potential LLP events.\n\n\
+    By integrating the CODEX-\u03B2 readout into the LHCb data stream, the experiment\
+    \ will validate its data acquisition model and demonstrate its scalability to\
+    \ the full detector. This integration also enables the tagging of events of interest\
+    \ in the LHCb detector, further enhancing its research capabilities."
+  question: What does the CODEX-b experiment do?
+- answer: The HL-LHC, or High-Luminosity Large Hadron Collider, is an upgrade to the
+    current Large Hadron Collider (LHC) at CERN. Its primary goal is to increase the
+    number of collisions by a factor of 10 beyond the LHC's original design. This
+    increase in luminosity will allow for more precise measurements and the potential
+    to observe rare processes that occur beyond the Standard Model of particle physics.
+    The HL-LHC aims to extend direct searches for new elementary particles, measure
+    the couplings of the Higgs boson with high precision, demonstrate the presence
+    of Higgs boson self-coupling, measure the couplings of the top quark with high
+    sensitivity to new physics, and enhance our overall understanding of fundamental
+    physics.
+  question: What is the HL-LHC?
+- answer: 'The muon collider, particularly at a center-of-mass energy of 10 TeV, is
+    envisioned to enable a comprehensive physics portfolio that includes ultimate
+    measurements in the Higgs sector. This implies that a muon collider would be highly
+    effective at measuring Higgs couplings, especially due to its high energy levels
+    which facilitate precise measurements and a broad search program. The ability
+    to precisely measure the coupling of the Higgs boson to itself is highlighted
+    as a significant advantage, providing insights into the shape of the Higgs potential
+    and the behavior of the electroweak phase transition.
+
+
+    On the other hand, the FCC-ee (Future Circular Collider-electron-positron) is
+    designed to operate at lower center-of-mass energies but with the highest luminosities,
+    creating a unique opportunity for a very rich set of fundamental measurements,
+    including determinations of Higgs couplings at the subpercent level. The FCC-ee''s
+    capability to indirectly discover new particles coupling to the Higgs and/or electroweak
+    bosons up to significant scales further underscores its precision and potential
+    for groundbreaking measurements in the Higgs sector.
+
+
+    In summary, both the muon collider and the FCC-ee are highly capable of measuring
+    Higgs couplings, but they do so in complementary energy regimes. The muon collider
+    excels with its high energy, enabling comprehensive and ultimate measurements,
+    while the FCC-ee leverages its high luminosity at lower energies to achieve precise
+    measurements of Higgs couplings at the subpercent level, along with a broad spectrum
+    of fundamental measurements and searches for new physics.'
+  question: How good is the muon collide at measuring Higgs couplings? How about FCCee?
+- answer: "The provided context does not offer specific predictions or performance\
+    \ metrics for Higgs boson pair (HH) production or analysis during LHC Run 3 or\
+    \ the High-Luminosity LHC (HL-LHC) phase. However, it does mention that the HL-LHC\
+    \ will \"dramatically expand the physics reach for Higgs physics\" and that with\
+    \ an integrated luminosity of 3 ab\u22121 and pp collisions at \u221As = 14 TeV,\
+    \ it will allow for \"precise measurements of Higgs\" among other studies. This\
+    \ suggests that the HL-LHC will significantly improve the study of Higgs boson\
+    \ pairs compared to previous runs, due to the increased dataset and the enhanced\
+    \ capabilities of the upgraded detectors.\n\nFor Run 3, while specific details\
+    \ on HH production are not provided, the nominal expectations for the LHC Run\
+    \ 3 include significant amounts of Pb-Pb and p-Pb collisions at high energies,\
+    \ and detector upgrades are mentioned which would benefit the overall physics\
+    \ program, including Higgs physics. These upgrades and the increased data from\
+    \ Run 3 are expected to improve the precision of measurements, although the exact\
+    \ impact on HH studies is not detailed.\n\nRegarding future colliders, the context\
+    \ does not mention any specific future collider projects or their potential performance\
+    \ relative to the HL-LHC in studying Higgs boson pairs. However, in the broader\
+    \ scientific discussion, there are several proposed future colliders (such as\
+    \ the Future Circular Collider (FCC) and the International Linear Collider (ILC))\
+    \ that aim to surpass the capabilities of the LHC and HL-LHC, potentially offering\
+    \ even more precise measurements of the Higgs boson and other particles. These\
+    \ future projects would likely provide further advancements in our understanding\
+    \ of particle physics, including HH production, but specific comparisons or projections\
+    \ are not provided in the given context."
+  question: How well will do on HH in Run 3? How about HL-LHC? Will any future collide
+    do better?
+- answer: The provided context does not specifically mention the roles or contributions
+    of IRIS-HEP (the Institute for Research and Innovation in Software for High-Energy
+    Physics) or HEP-CCE (High Energy Physics Center for Computational Excellence)
+    in preparing for the High-Luminosity Large Hadron Collider (HL-LHC). These organizations
+    are involved in high-energy physics research and have missions that support advancements
+    in computational science, software development, and data analysis techniques,
+    which are critical for managing the vast amounts of data generated by experiments
+    like those at the LHC. However, without specific details on their activities related
+    to the HL-LHC from the provided context, I cannot accurately describe what IRIS-HEP
+    and HEP-CCE will do to help prepare for the HL-LHC.
+  question: What will IRIS-HEP and HEP-CCE do to help prepare for the HL-LHC?
+- answer: Yes, there has been discussion and ongoing work on using machine learning
+    (ML) techniques for complete event reconstruction in high-energy physics (HEP)
+    experiments. The complexity of events, especially with high pileup scenarios like
+    those expected at the High-Luminosity Large Hadron Collider (HL-LHC), necessitates
+    the development of advanced algorithms that can manage the increased complexity
+    without significantly increasing the resources needed for per-event reconstruction.
+    This includes efforts to evolve or rewrite existing toolkits and algorithms with
+    a focus on their physics and technical performance in such high event complexity
+    environments. Machine learning algorithms are being developed and integrated into
+    various stages of the experimental process, including trigger and data acquisition
+    systems, to handle data reduction through advanced data selection and compression.
+    These efforts aim to enable efficient processing and analysis of the vast amounts
+    of data generated by HEP experiments, facilitating the search for new physics
+    phenomena.
+  question: Was there eny discussion of using ML to do complete event reconstruction?
+- answer: 'The prospects of Long-Lived Particle (LLP) searches at the High-Luminosity
+    Large Hadron Collider (HL-LHC) are highly promising and are expected to significantly
+    extend the sensitivity to LLPs compared to the capabilities of the main LHC detectors
+    alone. The HL-LHC, with its increased luminosity, will provide a much larger dataset,
+    allowing for more extensive searches for LLPs across various production and decay
+    modes. This enhancement in the search capabilities is crucial for probing new
+    physics beyond the Standard Model, including the exploration of dark matter candidates
+    and the investigation of mechanisms related to neutrino masses and the baryon
+    asymmetry of the universe (BAU).
+
+
+    One of the key experimental efforts in this direction is the Massive Timing Hodoscope
+    for Ultra-Stable neutraL pArticles (MATHUSLA) project. Situated at CERN near the
+    CMS detector, MATHUSLA is designed to specifically target LLPs, with the potential
+    to extend the sensitivity in long lifetime and LLP cross section by several orders
+    of magnitude. This would enable searches for LLPs with lifetimes near the upper
+    Big Bang Nucleosynthesis bound set by cosmology, significantly enhancing the physics
+    potential of the LHC in the search for new phenomena, including dark matter.
+
+
+    Furthermore, the HL-LHC era emphasizes the importance of incorporating LLP searches
+    into the baseline physics programs of future collider facilities from the start.
+    This approach ensures that detector designs and infrastructure plans are optimized
+    for LLP detection, maximizing the scientific output of these investments.
+
+
+    In summary, the prospects for LLP searches at the HL-LHC are highly promising,
+    with significant advancements expected in the understanding of LLPs and their
+    implications for physics beyond the Standard Model. The MATHUSLA project, along
+    with the strategic emphasis on LLP searches in future collider projects, underscores
+    the critical role these efforts play in exploring the frontiers of particle physics.'
+  question: What are the prospects of LLP searches at the HL-LHC?
+- answer: "The most recent Higgs boson mass measurements, as reported from CMS and\
+    \ ATLAS, set its value to 125.38 \xB1 0.14 GeV and 124.92 \xB1 0.21 GeV, respectively.\
+    \ These measurements use both the diphoton and ZZ decay channels for their analysis.\n\
+    \nWith the High-Luminosity Large Hadron Collider (HL-LHC), the precision of the\
+    \ Higgs boson mass measurement is expected to improve significantly. The HL-LHC\
+    \ is projected to provide a measurement of the Higgs boson mass to a precision\
+    \ of 10-20 MeV. This improvement is substantial compared to the current uncertainty\
+    \ levels and will significantly reduce the impact of this source of uncertainty\
+    \ on related measurements and theoretical predictions."
+  question: What is the current Higgs mass? How much will the uncertainty improve
+    with the HL-LHC?
+- answer: Based on the context provided, exploring models that predict light long-lived
+    particles (LLPs) with sub-GeV masses, such as the model featuring the light scalar
+    \(h_D\) field, seems promising for the high-luminosity Large Hadron Collider (HL-LHC).
+    This model is particularly interesting because it involves the \(h_D\) field coupling
+    to the Standard Model via mixing with the SM Higgs boson. The highly-displaced
+    decays of \(h_D\)s produced in the far-forward region of the LHC can be effectively
+    searched for in experiments like FASER2. Additionally, this model includes an
+    additional dark vector field \(A'\) with a mass range from GeV to over 100 GeV,
+    and a heavy complex scalar dark matter candidate \(\chi\), enriching the phenomenology
+    and offering multiple avenues for discovery at the HL-LHC.
+  question: What is a new LLP model that we should be exploring at the hl LHC?
+title: Standard questions for the Snowmass Whitepaper and Report Dataset


### PR DESCRIPTION
* Add command line option to specify the LLM model.
* Add the defaults command to give access to the chat LLM that gets used

Fixes #36