### PR TITLE
"Enable top_k setting"

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Getting from a list of documents to a working chat-bot follows the below steps:
         * `chatter -c snowmass/snowmass.yaml questions --questions_file snowmass/snowmass-questions.yaml compare snowmass/snowmass-v1.0.yaml snowmass/snowmass-v1.0-update.yaml`
         * This will write a table to your output terminal, but you can also generate a markdown file - see command line help for the `compare` sub-command.
 
+Use `chatter default list` to see what parameters are set by default when invoking the commands.
+
 ### Snowmass Info
 
 Included is a config file for `snowmass`.

--- a/chathelper/cli.py
+++ b/chathelper/cli.py
@@ -535,7 +535,7 @@ def questions_ask(args):
 def default_list(args):
     """List the defaults"""
     print(f"Query Model: {config_cache().query_model}")
-    print(f"Top K: {config_cache().top_k}")
+    print(f"Top k (# chunks of documents sent as context): {config_cache().top_k}")
 
 
 def default_set(args):


### PR DESCRIPTION
Fixes #34

This pull request includes the following changes:

- Create a `top_k` setting to set default # of fragments sent to the LLM to answer a question.
- Add documentation for the new top_k setting.

Fixes #34.